### PR TITLE
remove pypandoc since PyPI now supports Markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: python
 
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - "3.5"
 
 install:
   - python setup.py install
@@ -13,6 +10,5 @@ install:
 script:
   - cd tests
   - python run_tests.py
-  - pep8 run_tests.py
-  - cd ../geolinks
-  - pep8 __init__.py
+  - cd ..
+  - flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
-pep8
-pylint
+flake8

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2014 Tom Kralidis
+# Copyright (c) 2019 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -27,7 +27,8 @@
 #
 # =================================================================
 
-from distutils.core import setup
+from setuptools import find_packages, setup
+
 from geolinks import __version__ as version
 
 setup(
@@ -35,6 +36,7 @@ setup(
     version=version,
     description='Utilities to deal with geospatial links',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     license='MIT',
     platforms='all',
     keywords='links geo protocol url href',
@@ -43,7 +45,7 @@ setup(
     maintainer='Tom Kralidis',
     maintainer_email='tomkralidis@gmail.com',
     url='https://github.com/geopython/geolinks',
-    packages=['geolinks'],
+    packages=find_packages(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -52,12 +54,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: GIS',
     ]
 )

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2014 Tom Kralidis
+# Copyright (c) 2019 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -50,6 +50,7 @@ class GeolinksTest(unittest.TestCase):
             self.assertEqual(sniff_link(test['link']), test['expected'],
                              'Expected %s and %s to be equal' %
                              (test['link'], test['expected']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR removes Python 2.x support and bumps Travis testing to 3.5. It's time.