### PR TITLE
extend the sniffing capability to head out to the endpoint to find out what it is

### DIFF
--- a/geolinks/__init__.py
+++ b/geolinks/__init__.py
@@ -29,7 +29,6 @@
 
 import logging
 import sys
-
 import click
 from owslib.wms import WebMapService as WMS
 from owslib.wfs import WebFeatureService as WFS
@@ -59,6 +58,7 @@ def CLICK_OPTION_VERBOSITY(f):
     return click.option('--verbosity', '-v',
                         type=click.Choice(logging_options),
                         help='Verbosity',
+                        default='WARNING',
                         callback=callback)(f)
 
 def inurl(needles, haystack, position='any'):
@@ -250,18 +250,24 @@ def link():
 
 @click.command()
 @click.argument('link')
+@click.option("--probe", show_default=True, default=False, help="Probe the link to evaluate its type")
+@click.option("--first", show_default=True, default=True, help="Use the first protocol identified")
 @CLICK_OPTION_VERBOSITY
-def sniff(link, verbosity):
+
+
+def sniff(link, probe=False, first=True, verbosity='WARNING'):
     """Sniff link"""
 
     click.echo(f'Sniffing link: {link}')
 
-    link_type = sniff_link(link)
+    link_type = sniff_link(link, probe, first)
 
-	if isinstance(link_type, str):
-	    click.echo(f'Link type: {link_type}')
-	else:
-		click.echo(f'Link types: {link_type.join(",")}')
+    if (not link_type):
+        click.echo(f'No type detected')
+    elif isinstance(link_type, str):
+        click.echo(f'Link type: {link_type}')
+    else:
+        click.echo(f'Link types: {", ".join(link_type)}')
 
 link.add_command(sniff)
 cli.add_command(link)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click
+owslib

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -59,7 +59,7 @@ class GeolinksTest(unittest.TestCase):
         """simple link type tests"""
 
         for test in self.test_data['test_data']:
-            self.assertEqual(sniff_link(test['link']), test['expected'],
+            self.assertEqual(sniff_link(test['link'],extended=True), test['expected'],
                              'Expected %s and %s to be equal' %
                              (test['link'], test['expected']))
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -59,7 +59,7 @@ class GeolinksTest(unittest.TestCase):
         """simple link type tests"""
 
         for test in self.test_data['test_data']:
-            self.assertEqual(sniff_link(test['link'],extended=True), test['expected'],
+            self.assertEqual(sniff_link(test['link'], probe=test.get('probe',False), first=test.get('first',True)), test['expected'],
                              'Expected %s and %s to be equal' %
                              (test['link'], test['expected']))
 

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -1,6 +1,7 @@
 {
     "test_data": [
         {"link": "http://host/wms?service=WMS", "expected": "OGC:WMS"},
+        {"link": "https://maps.isric.org/mapserv?map=/map/bdod.map", "expected": "OGC:WMS"},
         {"link": "http://host/ows?service=WFS", "expected": "OGC:WFS"},
         {"link": "http://host/ows?service=WCS", "expected": "OGC:WCS"},
         {"link": "http://host/ows?service=WPS", "expected": "OGC:WPS"},

--- a/tests/test_data.json
+++ b/tests/test_data.json
@@ -1,7 +1,8 @@
 {
     "test_data": [
         {"link": "http://host/wms?service=WMS", "expected": "OGC:WMS"},
-        {"link": "https://maps.isric.org/mapserv?map=/map/bdod.map", "expected": "OGC:WMS"},
+        {"link": "https://maps.isric.org/mapserv?map=/map/bdod.map", "expected": "", "probe": "False"},
+        {"link": "https://maps.isric.org/mapserv?map=/map/bdod.map", "expected": "OGC:WMS", "probe": "True"},
         {"link": "http://host/ows?service=WFS", "expected": "OGC:WFS"},
         {"link": "http://host/ows?service=WCS", "expected": "OGC:WCS"},
         {"link": "http://host/ows?service=WPS", "expected": "OGC:WPS"},


### PR DESCRIPTION
Some comments:
- it may return an array of protocols, if multiple are supported
- for backwards compatibility, you need to set first=False to allow multiple (multiple is also slow)
- you need to set extended=True to activate the extended sniffing
- depends also on https://github.com/OSGeo/Cat-Interop/pull/38 to enforce the types on cat-interop

pending:
- tests
- docs