### PR TITLE
Document build time dependencies in pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@
 import io
 import os
 import re
-from setuptools import Command, find_packages, setup
 import sys
 
 from geolinks import __version__ as version
+from setuptools import Command, find_packages, setup
 
 
 class PyTest(Command):


### PR DESCRIPTION
geolinks 0.2.0 still uses the deprecated distutils which will be [removed in Python 3.12](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated).

This is fortunately already fixed in master where `setuptools` is used instead. The build time dependency on a third-party package is not documented though. Because `setup_requires` is deprecated, [PEP 517 (`pyproject.toml`)](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement) is used for the build time dependencies.

The imports are also [grouped according to PEP 8](https://peps.python.org/pep-0008/#imports).