### PR TITLE
add python_requires and list mandatory dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,5 +103,7 @@ setup(
         'Topic :: Scientific/Engineering :: GIS',
     ],
     cmdclass={'test': PyTest},
-    test_suite='tests.run_tests'
+    test_suite='tests.run_tests',
+    install_requires=["click"],
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
Even if installing from the wheel, see #10, the package won't work b/c it is missing a mandatory dependency on click.