### PR TITLE
add license file to the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE.md


### PR DESCRIPTION
The license is not included in the source distribution or the wheel. The MIT license does to keep a copy with the code.
This helps downstream packagers to be compliant with the license. 